### PR TITLE
Make all depends lowercase

### DIFF
--- a/cyg2deb.py
+++ b/cyg2deb.py
@@ -174,6 +174,7 @@ class Package:
                                       'mingw-w64-x86-64-dev')
             depends = depends.replace('_', '-')
             depends = depends.replace(' ', ',')
+            depends = depends.lower()
             f.write('Depends: ' + depends + lf)
             f.write('Section: cygwin\n')
             f.write('Priority: extra\n')


### PR DESCRIPTION
Make all depends lowercase to avoid  apt case-sensitive dependency issue

![image](https://user-images.githubusercontent.com/30096511/96351618-3eb1cd00-10ef-11eb-95c7-15d4523167d3.png)
